### PR TITLE
add excluded router for analytics

### DIFF
--- a/src/resources/js/router/excludeRouter.js
+++ b/src/resources/js/router/excludeRouter.js
@@ -1,0 +1,7 @@
+export default [
+  'ContentManagementBrowse', 
+  'ContentManagementRead', 
+  'ContentManagementFill', 
+  'ContentManagementEdit', 
+  'ContentManagementAdd',
+]


### PR DESCRIPTION
Create excludeRouter.js for excluding content module route from vue-gtag.